### PR TITLE
Bump version to v0.3.13. Minor fix to gulpfile and omitted superagent dependency.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('6to5/register')({
+require('babel/register')({
   ignore: false,
   only: /.+(?:(?:\.es6\.js)|(?:.jsx))$/,
   extensions: ['.js', '.es6.js', '.jsx' ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switcharoo",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "",
   "main": "src/app.es6.js",
   "scripts": {
@@ -32,6 +32,7 @@
     "serve-favicon": "2.2.0",
     "simple-oauth2": "0.2.1",
     "snoode": "0.2.4",
+    "superagent": "^0.21.0",
     "switcharoo-plugin-ads": "0.3.8",
     "switcharoo-plugin-core": "0.6.7",
     "switcharoo-plugin-metrics": "0.3.7"


### PR DESCRIPTION
:eyeglasses: @ajacksified 

Mostly wanted to make sure you knew I'm adding superagent back in. The build fails without it so I assume it's still used.